### PR TITLE
Fix spacing issue in README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-     - name: Install Node.js
+      - name: Install Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 16


### PR DESCRIPTION
there's a missing space in one of the README.md examples, it took me way too long to notice this and figure out why my GitHub Action workflow was failing to run until prettier gave me the very helpful error of:
```
SyntaxError: All collection items must start at the same column (11:5)
```
and then I realized the issue 😅