### PR TITLE
chore: bump node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,6 @@ inputs:
     required: false
     default: 'null'
 runs:
-  using: node12
+  using: node16
   main: dist/index.js
   post: dist/index.js


### PR DESCRIPTION
Avoid this warn:
![image](https://user-images.githubusercontent.com/18899748/194986792-fc121226-0131-4cd2-a722-b0b345c12983.png)

Update node version, see [github-actions-all-actions-will-begin-running-on-node16-instead-of-node12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12)
