### PR TITLE
Doc update to account for deprecated `set-output`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,12 @@ jobs:
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Setup pnpm cache
         with:
-          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-


### PR DESCRIPTION
Update doc to account for deprecated `set-output`.

The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

I've tested it on some of my repos and it seems to work perfectly. Gist here: https://gist.github.com/belgattitude/838b2eba30c324f1f0033a797bab2e31#composite-action

Related: #57