### PR TITLE
typo: not latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: pnpm/action-setup@v2.2.4
         with:

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ jobs:
         with:
           node-version: 16
 
-      - uses: pnpm/action-setup@v2.0.1
+      - uses: pnpm/action-setup@v2.2.4
         name: Install pnpm
         id: pnpm-install
         with:


### PR DESCRIPTION
Third instance of `- uses: pnpm/action-setup@vX.Y.Z` hasn't been updated for a minute, bringing it up to the version used [elsewhere in the README](https://github.com/pnpm/action-setup/commit/c3b53f6a16e57305370b4ae5a540c2077a1d50dd).
```diff
-      - uses: pnpm/action-setup@v2.0.1
+      - uses: pnpm/action-setup@v2.2.4
```

Edit: might as well bring the first occurrence of `actions/checkout` to `v3` too, to match the second occurrence.