### PR TITLE
Make url in error message clickable link

### DIFF
--- a/src/install-pnpm/run.ts
+++ b/src/install-pnpm/run.ts
@@ -49,7 +49,7 @@ Otherwise, please specify the pnpm version in the action configuration.`)
     throw new Error(`No pnpm version is specified.
 Please specify it by one of the following ways:
   - in the GitHub Action config with the key "version"
-  - in the package.json with the key "packageManager" (See https://nodejs.org/api/corepack.html)`)
+  - in the package.json with the key "packageManager" ( See https://nodejs.org/api/corepack.html )`)
   }
 
   if (!packageManager.startsWith('pnpm@')) {


### PR DESCRIPTION
URL in error message will be clickable element on browser. But current message is 404 because `)` is detected as part of url.

![9c0d9d28f18111bc87eb3bf70ded4a9f](https://user-images.githubusercontent.com/3257770/200432985-485ec7bb-da02-4642-8591-47fe8e298ba8.png)

This PR just insert spaces to fix.
