### PR TITLE
docs: update the caching example

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,21 +112,19 @@ jobs:
 
       - uses: pnpm/action-setup@v2
         name: Install pnpm
-        id: pnpm-install
         with:
           version: 7
           run_install: false
 
       - name: Get pnpm store directory
-        id: pnpm-cache
         shell: bash
         run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
       - uses: actions/cache@v3
         name: Setup pnpm cache
         with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-pnpm-store-


### PR DESCRIPTION
Without passing `--silent` I ran into `Error: Unable to process file command 'output' successfully.`. I'm not sure what the problem with `pnpm store path` was, but this fixed it.

Also, since this is running inside a single job, it seemed a little cleaner to use `env`.