### PR TITLE
Update nodejs version to 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,6 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: node16
+  using: node20
   main: dist/index.js
   post: dist/index.js


### PR DESCRIPTION
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: pnpm/action-setup@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.