### PR TITLE
Bump node version to node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,6 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: node16
+  using: node20
   main: dist/index.js
   post: dist/index.js


### PR DESCRIPTION
Hi, actions using node 16 are now producing warnings in the actions output. I've updated the action.yml to use node20

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/