### PR TITLE
fix: add missing `outputs` metadata to action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,11 @@ inputs:
     description: When set to true, @pnpm/exe, which is a Node.js bundled package, will be installed, enabling using pnpm without Node.js.
     required: false
     default: 'false'
+outputs:
+  dest:
+    description: Expanded path of inputs#dest
+  bin_dest:
+    description: Location of `pnpm` and `pnpx` command
 runs:
   using: node20
   main: dist/index.js


### PR DESCRIPTION
This PR adds `outputs` metadata to action.yml. The metadata is explained in the following official document:

https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs-for-docker-container-and-javascript-actions

Though it is optional, the metadata is useful for some static analysis. For example, [actionlint](https://github.com/rhysd/actionlint) can statically check the outputs are used correctly in a workflow.