### PR TITLE
docs: use cached pnpm installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'pnpm'
 
       - uses: pnpm/action-setup@v4
         name: Install pnpm


### PR DESCRIPTION
since this section is showing how to use a cache with pnpm, we should also use the cached pnpm installation