### PR TITLE
docs: change order of setup node and pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,17 +115,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'pnpm'
-
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
           version: 8
           run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
 
       - name: Get pnpm store directory
         shell: bash


### PR DESCRIPTION
I changed order of node setup and pnpm setup

There are error when setup node first in my case
> my case: https://github.com/git-goods/git-animal-client/actions/runs/9535208746/job/26280672324
> setup node docs: https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data