### PR TITLE
docs: remove redundant manual cache due to setup-node cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,19 +127,6 @@ jobs:
           node-version: 20
           cache: 'pnpm'
 
-      - name: Get pnpm store directory
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-
-      - uses: actions/cache@v4
-        name: Setup pnpm cache
-        with:
-          path: ${{ env.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
       - name: Install dependencies
         run: pnpm install
 ```


### PR DESCRIPTION
Removed the manual caching of the pnpm store since the setup-node action with `cache: "pnpm"` already handles it. The previous setup was creating two duplicate caches.

Closes #130