### PR TITLE
Add readme example for omitting `version`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ Location of `pnpm` and `pnpx` command.
 
 ## Usage example
 
-### Install only pnpm
+### Install only pnpm without `packageManager`
+
+This works when the repo either doesn't have a `package.json` or has a `package.json` but it doesn't specify `packageManager`.
 
 ```yaml
 on:
@@ -77,7 +79,7 @@ jobs:
           version: 8
 ```
 
-###  Install only pnpm, use `packageManager` version
+###  Install only pnpm with `packageManager`
 
 Omit `version` input to use the version in the [`packageManager` field in the `package.json`](https://nodejs.org/api/corepack.html).
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Location of `pnpm` and `pnpx` command.
 
 ## Usage example
 
-### Just install pnpm
+### Install only pnpm
 
 ```yaml
 on:
@@ -75,6 +75,23 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           version: 8
+```
+
+###  Install only pnpm, use `packageManager` version
+
+Omit `version` input to use the version in the [`packageManager` field in the `package.json`](https://nodejs.org/api/corepack.html).
+
+```yaml
+on:
+  - push
+  - pull_request
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: pnpm/action-setup@v4
 ```
 
 ### Install pnpm and a few npm packages


### PR DESCRIPTION
Hi @KSXGitHub @zkochan 👋

Quick PR to add a readme example for leaving out the `version` config input. This is is the solution for the `Multiple versions of pnpm specified` error messages encountered with #122.