### PR TITLE
Update examples to use pnpm v9

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ jobs:
     steps:
       - uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9
 ```
 
 ###  Install only pnpm with `packageManager`
@@ -116,7 +116,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9
           run_install: |
             - recursive: true
               args: [--frozen-lockfile, --strict-peer-dependencies]
@@ -141,7 +141,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 8
+          version: 9
           run_install: false
 
       - name: Install Node.js


### PR DESCRIPTION
pnpm v9 is out since 16 April 2024:

- https://x.com/pnpmjs/status/1780193331592486973