### PR TITLE
Only check `packageManager` if it actually specifies `pnpm`

### DIFF
--- a/src/install-pnpm/run.ts
+++ b/src/install-pnpm/run.ts
@@ -58,7 +58,7 @@ async function readTarget(opts: {
 
   if (version) {
     if (
-      typeof packageManager === 'string' &&
+      typeof packageManager === 'string' && packageManager.contains("pnpm@") &&
       packageManager.replace('pnpm@', '') !== version
     ) {
       throw new Error(`Multiple versions of pnpm specified:

--- a/src/install-pnpm/run.ts
+++ b/src/install-pnpm/run.ts
@@ -58,7 +58,7 @@ async function readTarget(opts: {
 
   if (version) {
     if (
-      typeof packageManager === 'string' && packageManager.includes("pnpm@") &&
+      typeof packageManager === 'string' && packageManager.includes('pnpm@') &&
       packageManager.replace('pnpm@', '') !== version
     ) {
       throw new Error(`Multiple versions of pnpm specified:

--- a/src/install-pnpm/run.ts
+++ b/src/install-pnpm/run.ts
@@ -58,7 +58,7 @@ async function readTarget(opts: {
 
   if (version) {
     if (
-      typeof packageManager === 'string' && packageManager.contains("pnpm@") &&
+      typeof packageManager === 'string' && packageManager.includes("pnpm@") &&
       packageManager.replace('pnpm@', '') !== version
     ) {
       throw new Error(`Multiple versions of pnpm specified:


### PR DESCRIPTION
We upgrade to version 4 and started seeing the following weird error:

```
Error: Multiple versions of pnpm specified:
  Error: Error: Multiple versions of pnpm specified:
    - version 9 in the GitHub Action config with the key "version"
    - version yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e in the package.json with the key "packageManager"
  Remove one of these versions to avoid version mismatch errors like ERR_PNPM_BAD_PM_VERSION
    - version 9 in the GitHub Action config with the key "version"
    - version yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e in the package.json with the key "packageManager"
```

Even though we don't specify `packageManager` in `package.json` explicitly.

Either way this change seems like an improvement to do `pnpm` version validation only if it's actually `pnpm`.