### PR TITLE
docs: correct use cache example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ jobs:
           version: 9
 ```
 
-###  Install only pnpm with `packageManager`
+### Install only pnpm with `packageManager`
 
 Omit `version` input to use the version in the [`packageManager` field in the `package.json`](https://nodejs.org/api/corepack.html).
 
@@ -148,7 +148,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'pnpm'
+          cache: pnpm
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
# problem

```yml
- name: Install Node.js
  uses: actions/setup-node@v4
  with:
    cache: 'pnpm'
```

use `'pnpm'` will make node action can't find cache, check example: https://github.com/tjx666/awesome-vscode-extension-boilerplate/actions/runs/10601263828/job/29380669132
