### PR TITLE
fix: not allow install multiple package manager

### DIFF
--- a/src/install-pnpm/run.ts
+++ b/src/install-pnpm/run.ts
@@ -64,6 +64,7 @@ async function readTarget(opts: {
   if (version) {
     if (
       typeof packageManager === 'string' &&
+      packageManager.startsWith('pnpm@') &&
       packageManager.replace('pnpm@', '') !== version
     ) {
       throw new Error(`Multiple versions of pnpm specified:


### PR DESCRIPTION
When a project has both npm and pnpm, using pnpm/action-setup will result in an error: `Multiple versions of pnpm specified`.

The previous implementation was only meant to avoid the `ERR_PNPM_BAD_PM_VERSION` error, but it did not take into account the situation of multiple different package managers.

My project structure:

```txt
/root
	package.json
		packageManger: npm@XXX

	sub-proj
		package.json
			packageManger: pnpm@YYY
```