### PR TITLE
Fix multiline run_install example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           version: 10
-          run_install: |
+          run_install:
             - recursive: true
               args: [--frozen-lockfile, --strict-peer-dependencies]
             - args: [--global, gulp, prettier, typescript]


### PR DESCRIPTION
Feel free to close if incorrect...

It seems like the multiline run example shouldn't have the `|` character since it's an object with properties.