### PR TITLE
Clarify that package_json_file is relative to GITHUB_WORKSPACE

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
     required: false
     default: 'null'
   package_json_file:
-    description: File path to the package.json to read "packageManager" configuration. This path must be relatve to the repository root (GITHUB_WORKSPACE).
+    description: File path to the package.json to read "packageManager" configuration. This path must be relative to the repository root (GITHUB_WORKSPACE).
     required: false
     default: 'package.json'
   standalone:


### PR DESCRIPTION
Clarify the description for `package_json_file` parameter to specify that the path must be relative to the repository root.

If, for example, you give an absolute file path, it doesn't work, because the provided path will always be prefixed by `GITHUB_WORKSPACE` at

https://github.com/pnpm/action-setup/blob/41ff72655975bd51cab0327fa583b6e92b6d3061/src/install-pnpm/run.ts#L64