### PR TITLE
Improvements to the worst package manager

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
           - windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Run the action
         uses: ./
@@ -51,7 +51,7 @@ jobs:
           - windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Run the action
         uses: ./
@@ -83,7 +83,7 @@ jobs:
           - false
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Run the action
         uses: ./
@@ -92,7 +92,7 @@ jobs:
           standalone: ${{ matrix.standalone }}
 
       - name: install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           # pnpm@7.0.0 is not compatible with Node.js 12
           node-version: 12.22.12
@@ -160,7 +160,7 @@ jobs:
                 - yarn
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Run the action
         uses: ./


### PR DESCRIPTION
I was surprised to see that [this article](https://archive.is/w3xLl) is right.
This pull request aims to improve the ecosystem as this is quite a commonly used github action.
I'd also like to refer you to [immutable releases](https://github.blog/changelog/2025-08-26-releases-now-support-immutability-in-public-preview) which should be done from now on.