### PR TITLE
docs: Update version to include devEngines.packageManager.version option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install pnpm package manager.
 
 Version of pnpm to install.
 
-**Optional** when there is a [`packageManager` field or `devEngines.packageManager.version` field in the `package.json`](https://nodejs.org/api/corepack.html).
+**Optional** when there is a [`packageManager` field or `devEngines.packageManager.name` is equal to "pnpm" and a `devEngines.packageManager.version` field in the `package.json`](https://nodejs.org/api/corepack.html).
 
 otherwise, this field is **required** It supports npm versioning scheme, it could be an exact version (such as `10.9.8`), or a version range (such as `10`, `10.x.x`, `10.9.x`, `^10.9.8`, `*`, etc.), or `latest`.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install pnpm package manager.
 
 Version of pnpm to install.
 
-**Optional** when there is a [`packageManager` field in the `package.json`](https://nodejs.org/api/corepack.html).
+**Optional** when there is a [`packageManager` field or `devEngines.packageManager.version` field in the `package.json`](https://nodejs.org/api/corepack.html).
 
 otherwise, this field is **required** It supports npm versioning scheme, it could be an exact version (such as `10.9.8`), or a version range (such as `10`, `10.x.x`, `10.9.x`, `^10.9.8`, `*`, etc.), or `latest`.
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that the version input is optional not only when a package manager is declared, but also when the devEngines package manager is set to "pnpm" and a package manager version is present in package.json. Updated linked reference text accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->