### PR TITLE
docs(README): fix `cache_dependency_path` type

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,33 @@ jobs:
 
 **Note:** You don't need to run `pnpm store prune` at the end; post-action has already taken care of that.
 
+### Cache dependencies from multiple lockfiles
+
+```yaml
+on:
+  - push
+  - pull_request
+
+jobs:
+  cache-and-install-multiple:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10
+          cache: true
+          cache_dependency_path: |
+            one/pnpm-lock.yaml
+            two/pnpm-lock.yaml
+          run_install: |
+            - cwd: one
+            - cwd: two
+```
+
 ## Notes
 
 This action does not setup Node.js for you, use [actions/setup-node](https://github.com/actions/setup-node) yourself.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If `run_install` is a YAML string representation of either an object or an array
 
 ### `cache_dependency_path`
 
-**Optional** (_type:_ `string|string[]`, _default:_ `pnpm-lock.yaml`) File path to the pnpm lockfile, which contents hash will be used as a cache key.
+**Optional** (_type:_ `string`, _default:_ `pnpm-lock.yaml`) File path to the pnpm lockfile, whose contents hash will be used as a cache key. Accepts multiple paths delimited by newlines.
 
 ### `package_json_file`
 

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
     required: false
     default: 'false'
   cache_dependency_path:
-    description: File path to the pnpm lockfile, which contents hash will be used as a cache key
+    description: File path to the pnpm lockfile, whose contents hash will be used as a cache key. Accepts multiple paths delimited by newlines.
     required: false
     default: 'pnpm-lock.yaml'
   package_json_file:


### PR DESCRIPTION
Fixes #218

The README indicates that `cache_dependency_path` can be an array of strings, but multiple paths should be provided as a newline-delimited string rather than an array.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified `cache_dependency_path` input: documented as a single string (default `pnpm-lock.yaml`), accepts multiple lockfile paths separated by newlines, and explains the cache key is derived from the specified lockfile(s) contents hash.
  * Added a README YAML example demonstrating caching using multiple newline-delimited lockfiles and corresponding install commands per directory.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pnpm/action-setup/pull/257)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->