### PR TITLE
docs(README): point users to the successor pnpm/setup action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+> [!IMPORTANT]
+> **This action has a successor: [`pnpm/setup`](https://github.com/pnpm/setup).**
+>
+> For pnpm v11 and newer, use [`pnpm/setup`](https://github.com/pnpm/setup) instead. It downloads pnpm's self-contained release binary (no Node.js or npm required) and can install a JavaScript runtime (Node.js, Bun, or Deno) in the same step, replacing `actions/setup-node`.
+>
+> `pnpm/action-setup` remains the action to use for installing pnpm v10 and older. See [Migrating to pnpm/setup](#migrating-to-pnpmsetup) below.
+
 > ## :warning: Upgrade from v2!
 >
 > The v2 version of this action [has stopped working](https://github.com/pnpm/action-setup/issues/135) with newer Node.js versions. Please, upgrade to the latest version to fix any issues.
@@ -5,6 +12,46 @@
 # Setup pnpm
 
 Install pnpm package manager.
+
+## Migrating to pnpm/setup
+
+[`pnpm/setup`](https://github.com/pnpm/setup) installs pnpm v11+ as a native standalone executable and can install Node.js, Bun, or Deno in the same step, so a typical workflow no longer needs `actions/setup-node` or an explicit `pnpm install` step:
+
+```yaml
+steps:
+  - uses: actions/checkout@v6
+
+  # Before:
+  # - uses: pnpm/action-setup@v6
+  #   with:
+  #     version: 10
+  #     cache: true
+  # - uses: actions/setup-node@v4
+  #   with:
+  #     node-version: 22
+  # - run: pnpm install
+
+  # After:
+  - uses: pnpm/setup@v1
+    with:
+      runtime: node@22
+      cache: true
+```
+
+Input and output changes:
+
+| `pnpm/action-setup` | `pnpm/setup` | Notes |
+| ------------------- | ------------ | ----- |
+| `version` | `version` | Must resolve to pnpm v11 or newer. As before, it can be omitted when `packageManager` (or `devEngines.packageManager`) is set in `package.json`. |
+| `dest` | `dest` | Unchanged. |
+| `run_install` | `install` | `pnpm/setup` runs `pnpm install` automatically when a `package.json` is present (`install: true` by default); set `install: false` to skip it. The object/array form (`recursive`, `cwd`, `args`) is not supported — run those commands in separate steps. |
+| `cache` | `cache` | Unchanged. |
+| `cache_dependency_path` | `cache-dependency-path` | Renamed to kebab-case. |
+| `package_json_file` | `package-json-file` | Renamed to kebab-case. |
+| `standalone` | removed | `pnpm/setup` always installs the standalone native executable. |
+| n/a | `runtime` | New: installs Node.js, Bun, or Deno (e.g. `node@22`, `bun@latest`, `deno@2`), or reads `devEngines.runtime` from `package.json`. |
+| n/a | `token` | New: GitHub token for release lookup; defaults to `${{ github.token }}` and rarely needs to be set. |
+| `bin_dest` (output) | `bin-dest` (output) | Renamed to kebab-case. New outputs `runtime-name` and `runtime-version` describe the installed runtime. |
 
 ## Inputs
 
@@ -187,7 +234,7 @@ jobs:
 
 ## Notes
 
-This action does not setup Node.js for you, use [actions/setup-node](https://github.com/actions/setup-node) yourself.
+This action does not setup Node.js for you, use [actions/setup-node](https://github.com/actions/setup-node) yourself. If you are on pnpm v11 or newer, [`pnpm/setup`](https://github.com/pnpm/setup) can install pnpm and Node.js in a single step.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 >
 > `pnpm/action-setup` remains the action to use for installing pnpm v10 and older. See [Migrating to pnpm/setup](#migrating-to-pnpmsetup) below.
 
-> ## :warning: Upgrade from v2!
->
-> The v2 version of this action [has stopped working](https://github.com/pnpm/action-setup/issues/135) with newer Node.js versions. Please, upgrade to the latest version to fix any issues.
-
 # Setup pnpm
 
 Install pnpm package manager.
+
+> ## :warning: Upgrade from v2!
+>
+> The v2 version of this action [has stopped working](https://github.com/pnpm/action-setup/issues/135) with newer Node.js versions. Please, upgrade to the latest version to fix any issues.
 
 ## Migrating to pnpm/setup
 
@@ -34,9 +34,12 @@ steps:
   # After:
   - uses: pnpm/setup@v1
     with:
+      version: 11
       runtime: node@22
       cache: true
 ```
+
+The `version` input can be omitted only when `packageManager` (or `devEngines.packageManager`) in `package.json` declares pnpm v11 or newer; otherwise keep it explicit, since `pnpm/setup` requires pnpm v11+.
 
 Input and output changes:
 
@@ -234,7 +237,7 @@ jobs:
 
 ## Notes
 
-This action does not setup Node.js for you, use [actions/setup-node](https://github.com/actions/setup-node) yourself. If you are on pnpm v11 or newer, [`pnpm/setup`](https://github.com/pnpm/setup) can install pnpm and Node.js in a single step.
+This action does not set up Node.js. Use [actions/setup-node](https://github.com/actions/setup-node) yourself. If you are on pnpm v11 or newer, [`pnpm/setup`](https://github.com/pnpm/setup) can install pnpm and Node.js in a single step.
 
 ## License
 


### PR DESCRIPTION
The pnpm setup action has a successor: [`pnpm/setup`](https://github.com/pnpm/setup) installs pnpm v11+ as a self-contained native executable and can install a JavaScript runtime (Node.js, Bun, or Deno) in the same step, replacing `actions/setup-node`. This README didn't mention it, so users landing here had no pointer to the new action or guidance on moving over.

This adds an important notice at the top pointing to the successor, a "Migrating to pnpm/setup" section with a before/after workflow example and an input/output mapping table (`run_install` becomes `install`, snake_case inputs renamed to kebab-case, `standalone` removed, new `runtime` and `token` inputs), and a short mention in the Notes section. Everything else stays intact since `pnpm/action-setup` remains the way to install pnpm v10 and older.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated guidance to recommend `pnpm/setup` for pnpm v11 and later.
  - Added migration instructions and input/output mappings.
  - Clarified runtime and dependency installation capabilities.
  - Linked the Notes section to new runtime installation information.
  - Improved transition guidance from the superseded setup action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->