### PR TITLE
ci: use pnpm 11 for `pr-check`

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           run_install: true
-          version: 9
+          version: 11
 
       - name: Update dist/index.js
         run: pnpm run build


### PR DESCRIPTION
Noticed while working on #283.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build validation environment to use pnpm version 11, ensuring distribution checks run with the latest configured package manager version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->